### PR TITLE
Make GT Scheduler backend more friendly to outside contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+Resolves #[issue-number]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+We welcome community contributions to the GT Scheduler project! Please read each of the following steps below to see how you can get started.
+
+1. Open or assign yourself to an Issue from the GT Scheduler [website repo](https://github.com/gt-scheduler/website). Note that Issues for the [crawler](https://github.com/gt-scheduler/crawler) and [backend](https://github.com/gt-scheduler/backend) repositories are created on the website repo (and are tagged with the `cross cutting` tag) in order to track all bugs/feature requests in a single place.
+
+   A rough overview of the tagging convention is as follows:
+
+   - An Issue with the `bug` tag is a bug report that should include details on how to reproduce the buggy behavior
+   - An Issue with the `feature request` tag is a feature request that can be addressed:
+     - directly with an implementation pull request
+     - or by using a separate (informal) RFC (request for comments) Issue tagged with `rfc` to facilitate design discussion and lead to an eventual implementation.
+   - An Issue with the `task` tag is designed to be a well-scoped unit of work made by the project maintainers, usually in the context of [Bits of Good](https://bitsofgood.org/) development. However, if an Issue with the `task` tag also has the `work needed` tag, feel free to assign yourself to it and work on it.
+
+2. If you are a maintainer or Bits of Good contributor with write access to the repository, feel create to create a branch directly using the described branching conventions here. For outside contributors, please fork the appropriate code repository that you are working on to your personal account.
+
+   Then, please create a new branch named using the following format:
+
+   ```
+   [your-first-name]/[issue-#]-[slug]
+   ```
+
+   For example, if...
+
+   - my first name was `George`
+   - I assigned myself to Issue `#57`
+   - Issue #57 is titled `"Add email support"`
+
+   Then I would name my branch:
+
+   ```
+   george/57-email-support
+   ```
+
+3. Do whatever the Issue asks in your branch (whether that be implementing a new feature or fixing an existing bug)
+
+   **Note on TypeScript**: While the crawler and backend projects are developed entirely in [TypeScript](https://www.typescriptlang.org/) (a typed superset of JavaScript), the website repo contains a mix of both JavaScript and TypeScript. Moving forwards, TypeScript is the preferred language to write new code in, so if you can, please use it when implementing a new feature.
+
+4. Make a PR between your branch and the appropriate primary branch that links to the Issue you want to resolve. The exact branch depends on the repository you are making a PR to:
+   - For the [website repo](https://github.com/gt-scheduler/website), the appropriate branch is `development`
+   - For the [crawler repo](https://github.com/gt-scheduler/crawler), the appropriate branch is `master`
+   - For the [backend repo](https://github.com/gt-scheduler/backend), the appropriate branch is `main`
+5. Get at least one other contributor to review your PR and make comments when necessary.
+6. Merge your PR once it has been approved!
+
+If you have any questions or concerns, feel free to [open a discussion](https://github.com/gt-scheduler/website/discussions) on the GT Scheduler website repository, or for Bits of Good contributors, feel free to ask a question in the #gt-scheduler channel within the Hack4Impact slack.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Sample: [202008.json](https://gt-scheduler.github.io/crawler/202008.json)
 
+To report a bug or request a new feature, please [create a new Issue in the GT Scheduler website repository](https://github.com/gt-scheduler/website/issues/new/choose).
+
 ## 📃 License & Copyright Notice
 
 This work is a derivative of the original and spectacular [GT Schedule Crawler](https://github.com/64json/gt-schedule-crawler) project created by Jinseo Park (as a part of the overall [GT Scheduler](https://github.com/64json/gt-scheduler) project). The original work and all modifications are licensed under the [AGPL v3.0](https://github.com/64json/gt-scheduler/blob/master/LICENSE) license.
@@ -15,3 +17,42 @@ Copyright (c) 2020 Jinseo Park (parkjs814@gmail.com)
 ### Modifications
 
 Copyright (c) 2020 the Bits of Good "GT Scheduler" team
+
+## 🔍 Overview
+
+The crawler is a command-line application written in [TypeScript](https://www.typescriptlang.org/) (a typed superset of JavaScript) that runs using Node.js to crawl schedule data from [Oscar](https://oscar.gatech.edu/) (Georgia Tech's registration management system).
+
+It operates as a series of *steps* that are processed after one another (see [`src/index.ts`](/src/index.ts)) for each current "term" (combination of year and semester, i.e. Fall 2021).
+
+In order to process the prerequisites data for each course (which comes in the form of a string like "Undergraduate Semester level CS 2340 Minimum Grade of C and Undergraduate Semester level LMC 3432 Minimum Grade of C" that can become much more complex), the crawler also utilizes an [ANTLR](https://www.antlr.org/) grammar and generated parser in order to convert the prerequisites data retrieved from Oscar into a normalized tree structure. The grammar itself and the generated parser/lexer code can be found in the [`src/steps/prereqs/grammar`](/src/steps/prereqs/grammar) folder.
+
+The crawler is run every 30 minutes using a [GitHub Action workflow](/.github/workflows/crawling.yml), which then publishes the resultant JSON to the `gh-pages` where it can be downloaded by the frontend app: https://gt-scheduler.github.io/crawler/202008.json.
+
+## 🚀 Running Locally
+
+- [Node.js](https://nodejs.org/en/) (any recent version will probably work)
+- Installation of the [`yarn` package manager](https://classic.yarnpkg.com/en/docs/install/) **version 1** (support for version 2 is untested)
+
+### Running the crawler
+
+After cloning the repository to your local computer, run the following command in the repo folder:
+
+```
+yarn install
+```
+
+This may take a couple minutes and will create a new folder called `node_modules` with all of the dependencies installed within. This only needs to be run once.
+
+Then, to run the crawler, run:
+
+```
+yarn start
+```
+
+After the crawler runs (which can take 10-20 minutes), a series of JSON files should have been created in a new `data` directory in the project root.
+
+## 👩‍💻 Contributing
+
+The GT Scheduler project welcomes (and encourages) contributions from the community. Regular development is performed by the project owners (Jason Park and [Bits of Good](https://bitsofgood.org/)), but we still encourage others to work on adding new features or fixing existing bugs and make the registration process better for the Georgia Tech community.
+
+More information on how to contribute can be found [in the contributing guide](/CONTRIBUTING.md).


### PR DESCRIPTION
Resolves #1

- Adds CONTRIBUTING.md guide
- Cleans up README.md
- Adds Pull request template
- No Issue templates are included since issues should be directed to the website repo
