### PR TITLE
Add generated files to exclude-list for linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Ignore everything in src/steps/prereqs/grammar because it is generated,
+# except for Prerequisites.g4 and README.md
+src/steps/prereqs/grammar/* linguist-generated
+src/steps/prereqs/grammar/Prerequisites.g4  -linguist-generated
+src/steps/prereqs/grammar/README.md -linguist-generated


### PR DESCRIPTION
### Summary

Small change, just adds a `.gitattributes` file and exludes the TypeScript generated files from `antlr4ts`. This will change the languages breakdown for the repo on GitHub (more info here: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md)

#### Linguist stats before

```
$ github-linguist .
98.19%  67254      TypeScript
1.81%   1241       ANTLR
```

#### Linguist stats after


```
$ github-linguist .
96.49%  34075      TypeScript
3.51%   1241       ANTLR
```
