### PR TITLE
Use a machine account for crawled commits

### DIFF
--- a/.github/workflows/crawling.yml
+++ b/.github/workflows/crawling.yml
@@ -22,10 +22,12 @@ jobs:
         run: yarn start
 
       - name: Upload
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: data
-          CLEAN: false
-          SINGLE_COMMIT: true
+          token: ${{ secrets.CRAWLER_DEPLOY_PERSONAL_ACCESS_TOKEN }}
+          branch: gh-pages
+          folder: data
+          clean: false
+          single-commit: true
+          git-config-name: gt-scheduler-bot
+          git-config-email: 89671168+gt-scheduler-bot@users.noreply.github.com


### PR DESCRIPTION
### Summary

- Upgrades `JamesIves/github-pages-deploy-action` action to v4
- Adds a personal account token and git name/email for @gt-scheduler-bot, a machine account recently created that will be credited with crawled commits.

### Motivation

While having all of the commits be attributed to me is cool and all, it's filling up my profile page with a bunch of noise that I'd just rather not have.

