### PR TITLE
Add structured logging & make crawler much faster

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,7 +20,6 @@ rules:
 
   # Too pedantic / sometimes encourages Node anti-patterns
   import/prefer-default-export: off
-  no-console: 0
   no-await-in-loop: 0
   no-restricted-syntax: 0
   class-methods-use-this: 0

--- a/.github/workflows/crawling.yml
+++ b/.github/workflows/crawling.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Crawling
         run: yarn start
+        with:
+          LOG_FORMAT: json
 
       - name: Upload
         uses: JamesIves/github-pages-deploy-action@releases/v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 data
 .DS_Store
 .antlr
+*.log

--- a/README.md
+++ b/README.md
@@ -49,7 +49,25 @@ Then, to run the crawler, run:
 yarn start
 ```
 
-After the crawler runs (which can take 10-20 minutes), a series of JSON files should have been created in a new `data` directory in the project root.
+After the crawler runs, a series of JSON files should have been created in a new `data` directory in the project root.
+
+#### Utilizing structured logging
+
+By default, the crawler outputs standard log lines to the terminal in development. However, it also supports outputting structured JSON log events that can be more easily parsed and analyzed when debugging. This is turned on by default when the crawler is running in a GitHub Action (where the `LOG_FORMAT` environment variable is set to `json`), but it can also be enabled for development.
+
+The utility script `yarn start-logged` can be used to run the crawler and output JSON log lines to a logfile in the current working directory:
+
+```
+yarn start-logged
+```
+
+To analyze the JSON log lines data, I recommend using [`jq`](https://stedolan.github.io/jq/) since it is a powerful tool for parsing/analyzing JSON in the shell. The following command imports all lines in the latest log file and loads them all as one large array for further processing (**note**: this command will probably only work on Unix-like systems (Linux and probably macOS), so your mileage may vary. If you're running into issues, try running it on a Linux computer and make sure you have [`jq` installed](https://stedolan.github.io/jq/)):
+
+```sh
+cat $(find . -type f -name "*.log" | sort -n | tail -1) | jq -cs '.'
+```
+
+For some useful queries on the log data, see [📚 Useful queries on crawler logs](https://github.com/gt-scheduler/crawler/wiki/%F0%9F%93%9A-Useful-queries-on-crawler-logs).
 
 ### Linting
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "ts-node src",
+    "start-logged": "logfile=\"$(date --iso-8601=seconds).log\"; echo \"Logging to '$logfile'\"; LOG_FORMAT=json ts-node src > \"$logfile\" 2>&1; echo 'Done'",
     "gen-parser": "antlr4ts -visitor src/steps/prereqs/grammar/Prerequisites.g4",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.ts\" --ignore-pattern \"src/steps/prereqs/grammar/**/*\"",
@@ -12,10 +13,14 @@
   },
   "dependencies": {
     "antlr4ts": "^0.5.0-alpha.3",
-    "axios": "^0.18.1"
+    "axios": "^0.18.1",
+    "exponential-backoff": "^3.1.0",
+    "fast-safe-stringify": "^2.0.8",
+    "tiny-async-pool": "^1.2.0"
   },
   "devDependencies": {
     "@types/node": "^14.0.24",
+    "@types/tiny-async-pool": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
     "antlr4ts-cli": "^0.5.0-alpha.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,169 @@
+import asyncPool from "tiny-async-pool";
 import {
   download,
   list,
   parse,
-  downloadDetails,
-  parsePrereqs,
-  attachPrereqs,
+  downloadCourseDetails,
   attachDescriptions,
-  parseDescriptions,
+  attachPrereqs,
   write,
+  parseCourseDescription,
+  parseCoursePrereqs,
 } from "./steps";
+import { Prerequisites } from "./types";
+import { setLogFormat, isLogFormat, log, error, span, warn } from "./log";
+
+// Number of terms to scrape (scrapes most recent `NUM_TERMS`)
+const NUM_TERMS = 2;
 
 // Current scraped JSON version
 const CURRENT_VERSION = 2;
 
-async function crawling() {
-  console.info("Listing ...");
-  const terms = await list();
+// IO Concurrency to download files using.
+// This is a completely arbitrary number.
+const DETAILS_CONCURRENCY = 256;
 
-  for (const term of terms.slice(0, 2)) {
-    console.info(`Downloading ${term} ...`);
-    const html = await download(term);
+async function main(): Promise<void> {
+  const rawLogFormat = process.env.LOG_FORMAT;
+  if (rawLogFormat != null) {
+    if (isLogFormat(rawLogFormat)) {
+      setLogFormat(rawLogFormat);
+    } else {
+      warn(`invalid log format provided`, { logFormat: rawLogFormat });
+      process.exit(1);
+    }
+  } else {
+    setLogFormat("text");
+  }
 
-    console.info(`Parsing v${CURRENT_VERSION} JSON ...`);
-    const termData = await parse(html, CURRENT_VERSION);
-
-    const allCourseIds = Object.keys(termData.courses);
-    const detailPromises = downloadDetails(term, allCourseIds);
-
-    // Pass in the detail promise array twice
-    // Each async function will await them,
-    // but since promises are immutable, this is fine
-    console.log(
-      "Downloading prerequisite information & course descriptions ..."
-    );
-    const prereqParsePromise = parsePrereqs(detailPromises);
-    const descriptionPromise = parseDescriptions(detailPromises);
-
-    // Await the promises in parallel
-    const [prereqs, descriptions] = await Promise.all([
-      prereqParsePromise,
-      descriptionPromise,
-    ]);
-
-    console.info("Attaching prerequisite information ...");
-    attachPrereqs(termData, prereqs);
-
-    console.info("Attaching course descriptions ...");
-    attachDescriptions(termData, descriptions);
-
-    console.info("Writing ...");
-    await write(term, termData);
+  try {
+    // Create a new top-level span for the entire crawler operation.
+    // This simply logs when before/after the operation
+    // so we know how long it took.
+    await span(`crawling Oscar`, {}, async () => crawl());
+    process.exit(0);
+  } catch (err) {
+    error(`a fatal error occurred while running the crawler`, err);
+    process.exit(1);
   }
 }
 
-crawling().catch(console.error);
+async function crawl(): Promise<void> {
+  const termsToScrape = await span(
+    `listing all terms`,
+    {},
+    async (setFinishFields) => {
+      const terms = await list();
+      const recentTerms = terms.slice(0, NUM_TERMS);
+      setFinishFields({ terms, recentTerms, desiredNumTerms: NUM_TERMS });
+      return recentTerms;
+    }
+  );
+
+  // Scrape each term in parallel
+  await Promise.all(
+    termsToScrape.map(async (term) => {
+      // Set the base fields that are added to every span
+      const termSpanFields: Record<string, unknown> = {
+        term,
+        version: CURRENT_VERSION,
+      };
+
+      await span(`crawling term`, termSpanFields, () =>
+        crawlTerm(term, termSpanFields)
+      );
+    })
+  );
+}
+
+async function crawlTerm(
+  term: string,
+  baseSpanFields: Record<string, unknown>
+): Promise<void> {
+  // Alias the parameter so we can modify it
+  let spanFields = baseSpanFields;
+
+  // Download the term HTML page containing every course.
+  const html = await span(`downloading term`, spanFields, () => download(term));
+
+  const termData = await span(`parsing term data to JSON`, spanFields, () =>
+    parse(html, CURRENT_VERSION)
+  );
+
+  const allCourseIds = Object.keys(termData.courses);
+  const courseIdCount = allCourseIds.length;
+  spanFields = { ...spanFields, courseIdCount };
+  log(`collected all course ids`, { allCourseIds, ...spanFields });
+
+  const prereqs: Record<string, Prerequisites | []> = {};
+  const descriptions: Record<string, string | null> = {};
+  await span(
+    `downloading & parsing prerequisite info & course descriptions`,
+    { ...spanFields, concurrency: DETAILS_CONCURRENCY },
+    async () =>
+      asyncPool(DETAILS_CONCURRENCY, allCourseIds, async (courseId) => {
+        const courseSpanFields = {
+          ...spanFields,
+          courseId,
+        };
+
+        const [coursePrereqs, courseDescription] = await span(
+          `crawling individual course`,
+          courseSpanFields,
+          () => crawlCourseDetails(term, courseId, courseSpanFields)
+        );
+
+        prereqs[courseId] = coursePrereqs;
+        descriptions[courseId] = courseDescription;
+      })
+  );
+
+  await span(`attaching prereq information`, spanFields, () =>
+    attachPrereqs(termData, prereqs)
+  );
+
+  await span(`attaching course descriptions`, spanFields, () =>
+    attachDescriptions(termData, descriptions)
+  );
+
+  await span(`writing scraped data to disk`, spanFields, () =>
+    write(term, termData)
+  );
+}
+
+async function crawlCourseDetails(
+  term: string,
+  courseId: string,
+  baseSpanFields: Record<string, unknown>
+): Promise<[prereqs: Prerequisites | [], descriptions: string | null]> {
+  // Alias the parameter so we can modify it
+  const spanFields = baseSpanFields;
+
+  const detailsHtml = await span(
+    `downloading course details`,
+    spanFields,
+    async (setFinishFields) => {
+      const result = await downloadCourseDetails(term, courseId);
+      setFinishFields({ htmlLength: result.length });
+      return result;
+    }
+  );
+
+  const prereqs = await span(`parsing course prereqs`, spanFields, () =>
+    parseCoursePrereqs(detailsHtml, courseId)
+  );
+
+  const description = await span(
+    `parsing course description`,
+    spanFields,
+    (setFinishFields) => {
+      const descriptionOption = parseCourseDescription(detailsHtml, courseId);
+      setFinishFields({ hadDescription: descriptionOption != null });
+      return descriptionOption;
+    }
+  );
+
+  return [prereqs, description];
+}
+
+main();

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,303 @@
+import process from "process";
+import safeStringify from "fast-safe-stringify";
+
+export type LogFormat = "json" | "text";
+
+let logFormat: LogFormat = "text";
+
+/**
+ * Custom type guard for determining if a string is a valid log format
+ */
+export function isLogFormat(rawLogFormat: string): rawLogFormat is LogFormat {
+  switch (rawLogFormat) {
+    case "json":
+    case "text":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Sets the global log format used for any future calls to `log`,
+ * its derivatives, or any Span functions
+ */
+export function setLogFormat(newLogFormat: LogFormat): void {
+  logFormat = newLogFormat;
+}
+
+/**
+ * Base logging function that logs at level="info"
+ * @param message - static message, used for grepping logs
+ * @param fields - structured fields (should be string-serializable)
+ */
+export function log(
+  message: string,
+  fields: Record<string, unknown> = {}
+): void {
+  if (logFormat === "json") {
+    // eslint-disable-next-line no-console
+    console.log(
+      safeStringify({
+        ts: new Date().toISOString(),
+        message,
+        level: "info",
+        ...fields,
+      })
+    );
+  } else {
+    const fieldsAsStrings: Record<string, string> = {
+      level: "info",
+    };
+    Object.entries(fields).forEach(([key, value]) => {
+      if (typeof value === "object") {
+        fieldsAsStrings[key] = safeStringify(value);
+      } else {
+        fieldsAsStrings[key] = String(value);
+      }
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(
+      [
+        `[${new Date().toISOString()}]`,
+        message,
+        ...Object.entries(fieldsAsStrings).map(
+          ([key, value]) => `${key}='${value}'`
+        ),
+      ].join(" ")
+    );
+  }
+}
+
+/**
+ * Base logging function that logs at level="info"
+ * @param message - static message, used for grepping logs
+ * @param fields - structured fields (should be string-serializable)
+ */
+export function info(
+  message: string,
+  fields: Record<string, unknown> = {}
+): void {
+  log(message, fields);
+}
+
+/**
+ * Base logging function that logs at level="warn"
+ * @param message - static message, used for grepping logs
+ * @param fields - structured fields (should be string-serializable)
+ */
+export function warn(
+  message: string,
+  fields: Record<string, unknown> = {}
+): void {
+  log(message, { level: "warn", ...fields });
+}
+
+/**
+ * Performs a best-effort serialization of the error into structured fields
+ * @param err - the raw error object or unknown
+ * @param includeStack - whether to include the stacktrace in "stack"
+ * @returns a structured log fields record
+ */
+export function errorFields(
+  err: unknown,
+  includeStack = false
+): Record<string, unknown> {
+  const { message: errorMessage, stack } = err as {
+    message?: string;
+    stack?: string;
+  };
+
+  // Perform a best-effort serialization of the error
+  let errorAsString = String(err);
+  if (errorAsString === "[object Object]") {
+    errorAsString = safeStringify(err);
+  }
+
+  const fields: Record<string, unknown> = {
+    error: errorAsString,
+    errorMessage,
+  };
+
+  if (includeStack) {
+    fields.stack = stack;
+  }
+
+  return fields;
+}
+
+/**
+ * Base logging function that logs at level="error",
+ * including explicit error-related fields.
+ * @param message - static message, used for grepping logs
+ * @param err - error object or null/undefined
+ * @param fields - structured fields (should be string-serializable)
+ */
+export function error(
+  message: string,
+  err: unknown,
+  fields: Record<string, unknown> = {}
+): void {
+  log(message, {
+    level: "error",
+    ...errorFields(err, true),
+    ...fields,
+  });
+}
+
+/**
+ * Creates a new span with the given base message, starting it immediately
+ * @param baseMessage - static message, used for grepping logs
+ * @param fields - structured fields (should be string-serializable)
+ * @returns a new `Span` instance
+ */
+export function startSpan(
+  baseMessage: string,
+  fields: Record<string, unknown> = {}
+): Span {
+  const currentSpan = new Span(baseMessage, fields);
+  currentSpan.start();
+  return currentSpan;
+}
+
+/**
+ * Runs an entire operation in a span
+ * @param baseMessage - static message, used for grepping logs
+ * @param fields - structured fields (should be string-serializable)
+ * @param execute - async callback. Optional function `setCompletionFields`
+ * passed in as parameter allows callback to set additional fields
+ * for the span finish event.
+ * @returns
+ */
+export async function span<R>(
+  baseMessage: string,
+  fields: Record<string, unknown>,
+  execute: (
+    setCompletionFields: (additionalFields: Record<string, unknown>) => void
+  ) => Promise<R> | R
+): Promise<R> {
+  // Allow the callback to register additional fields upon completion
+  let completionFields: Record<string, unknown> = {};
+  const setCompletionFields = (additionalFields: Record<string, unknown>) => {
+    completionFields = { ...completionFields, ...additionalFields };
+  };
+
+  // Run the operation in a new span
+  const currentSpan = new Span(baseMessage, fields);
+  currentSpan.start();
+  try {
+    const resultOrPromise = execute(setCompletionFields);
+    let result: R;
+    if (resultOrPromise instanceof Promise) {
+      result = await resultOrPromise;
+    } else {
+      result = resultOrPromise;
+    }
+
+    currentSpan.finish(completionFields);
+
+    return result;
+  } catch (err) {
+    currentSpan.error(err, completionFields);
+    throw err;
+  }
+}
+
+/**
+ * Represents a span operation that includes timing information
+ * and structured logging
+ */
+export class Span {
+  baseMessage: string;
+
+  fields: Record<string, unknown>;
+
+  startTime: [number, number] | null;
+
+  /**
+   * Creates a new span without starting it
+   * @param baseMessage - static message, used for grepping logs
+   * @param fields - structured fields (should be string-serializable)
+   */
+  constructor(baseMessage: string, fields: Record<string, unknown> = {}) {
+    this.baseMessage = baseMessage;
+    this.fields = fields;
+    this.startTime = null;
+  }
+
+  /**
+   * Emits a span event as a log line
+   * @param event - the type of the span event
+   * @param additionalFields - additional structured fields
+   * (should be string-serializable)
+   */
+  spanEvent(
+    event: "start" | "finish" | "error",
+    additionalFields: Record<string, unknown> = {}
+  ): void {
+    if (logFormat === "json") {
+      log(this.baseMessage, {
+        spanEvent: event,
+        ...this.fields,
+        ...additionalFields,
+      });
+    } else {
+      const eventPrefix = `${event}ed`;
+      // 8 is the length of the longest possible event prefix, "finished"
+      log(`${eventPrefix.padStart(8)} ${this.baseMessage}`, {
+        ...this.fields,
+        ...additionalFields,
+      });
+    }
+  }
+
+  /**
+   * Starts a previously-constructed span, emitting a span start event
+   * and noting the start time in the `Span` object
+   */
+  start(): void {
+    this.spanEvent("start");
+    this.startTime = process.hrtime();
+  }
+
+  getElapsedMs(): number {
+    if (this.startTime === null) {
+      throw new Error(
+        `Span has not yet started: baseMessage="${this.baseMessage}"`
+      );
+    }
+
+    // Gives [seconds, nanoseconds]
+    const end = process.hrtime(this.startTime);
+    return end[0] * 1_000 + end[1] / 1_000_000;
+  }
+
+  /**
+   * Finishes a previously-started span, emitting a span finish event
+   * that includes the elapsed time since the call to `start`
+   * @param additionalFields - additional structured fields
+   * (should be string-serializable)
+   */
+  finish(additionalFields: Record<string, unknown> = {}): void {
+    this.spanEvent("finish", {
+      elapsedMs: this.getElapsedMs(),
+      ...additionalFields,
+    });
+  }
+
+  /**
+   * Finishes a previously-started span, emitting a span error event
+   * that includes the elapsed time since the call to `start`
+   * @param additionalFields - additional structured fields
+   * (should be string-serializable)
+   */
+  error(err: unknown, additionalFields: Record<string, unknown> = {}): void {
+    this.spanEvent("error", {
+      level: "error",
+      elapsedMs: this.getElapsedMs(),
+      ...errorFields(err, false),
+      ...additionalFields,
+    });
+  }
+}

--- a/src/steps/descriptions/attach.ts
+++ b/src/steps/descriptions/attach.ts
@@ -1,3 +1,4 @@
+import { warn } from "../../log";
 import { TermData } from "../../types";
 
 /**
@@ -9,14 +10,17 @@ import { TermData } from "../../types";
  */
 export function attachDescriptions(
   termData: TermData,
-  descriptions: Record<string, string>
+  descriptions: Record<string, string | null>
 ): void {
   Object.keys(descriptions).forEach((courseId) => {
+    // Skip null descriptions
+    if (descriptions[courseId] === null) return;
+
     if (courseId in termData.courses) {
       // eslint-disable-next-line no-param-reassign
       termData.courses[courseId][3] = descriptions[courseId];
     } else {
-      console.warn(`Received description for unknown course '${courseId}'`);
+      warn(`received description for unknown course`, { courseId });
     }
   });
 }

--- a/src/steps/descriptions/parse.ts
+++ b/src/steps/descriptions/parse.ts
@@ -1,25 +1,5 @@
+import { warn } from "../../log";
 import { regexExec } from "../../utils";
-
-/**
- * Parses the HTML for each course detail page in parallel,
- * awaiting on all of them at the end to construct the global course id -> description map
- * @param promises - List of promises from downloadDetails(...)
- */
-export async function parseDescriptions(
-  promises: Promise<[courseId: string, html: string]>[]
-): Promise<Record<string, string>> {
-  const allDescriptions: Record<string, string> = {};
-  const parsePromises = promises.map(async (promise) => {
-    const [courseId, html] = await promise;
-    const descriptionOption = parseCourseDescription(html, courseId);
-    if (descriptionOption != null) {
-      allDescriptions[courseId] = descriptionOption;
-    }
-  });
-
-  await Promise.all(parsePromises);
-  return allDescriptions;
-}
 
 const descriptionRegex = /<TD CLASS="ntdefault">([\s\S]*?)<br \/>/;
 
@@ -28,7 +8,10 @@ const descriptionRegex = /<TD CLASS="ntdefault">([\s\S]*?)<br \/>/;
  * @param html - Source HTML from the course details page
  * @param courseId - The joined course id (SUBJECT NUMBER); i.e. `"CS 2340"`
  */
-function parseCourseDescription(html: string, courseId: string): string | null {
+export function parseCourseDescription(
+  html: string,
+  courseId: string
+): string | null {
   try {
     // Get the first match of the description content regex
     const [, contents] = regexExec(descriptionRegex, html);
@@ -44,9 +27,7 @@ function parseCourseDescription(html: string, courseId: string): string | null {
 
     return trimmed;
   } catch {
-    console.warn(
-      `Could not execute course description regex for '${courseId}'`
-    );
+    warn(`could not execute course description regex`, { courseId });
     return null;
   }
 }

--- a/src/steps/details.ts
+++ b/src/steps/details.ts
@@ -1,30 +1,7 @@
 import axios from "axios";
+import { backOff } from "exponential-backoff";
 import { concatParams } from "../utils";
-
-// The delay between sequential requests, in ms
-const DELAY_PER_REQUEST = 100;
-
-/**
- * Downloads the course detail information for all provided courses in parallel
- * (**note**: returns an array of promises to allow for parallel downstream processing)
- * @param term - The term string
- * @param courseId - An array of joined course ids (SUBJECT NUMBER); i.e. `"CS 2340"`
- */
-export function downloadDetails(
-  term: string,
-  courseIds: string[]
-): Promise<[courseId: string, html: string]>[] {
-  // Note: it is very important that we construct an array of promises here
-  // and let downstream components wait on all of them at the end (in parallel)
-  // instead of awaiting them one by one (in series).
-  // However, because we do this, we need to be careful
-  // that we don't get rate limited/run into issues with connection limits.
-  // To solve this, we sleep for varying amounts
-  return courseIds.map(async (courseId, i) => {
-    await new Promise((r) => setTimeout(r, i * DELAY_PER_REQUEST));
-    return downloadCourseDetails(term, courseId);
-  });
-}
+import { warn, error } from "../log";
 
 /**
  * Downloads the course detail information for a single course
@@ -34,14 +11,12 @@ export function downloadDetails(
 export async function downloadCourseDetails(
   term: string,
   courseId: string
-): Promise<[courseId: string, html: string]> {
+): Promise<string> {
   // Attempt to split the course ID into its subject/number
   const splitResult = splitCourseId(courseId);
   if (splitResult === null) {
-    console.warn(
-      `Could not split course ID '${courseId}'; skipping detail scraping for it`
-    );
-    return [courseId, ""];
+    warn("could not split course ID; skipping detail scraping", { courseId });
+    return "";
   }
 
   const [subject, number] = splitResult;
@@ -51,36 +26,32 @@ export async function downloadCourseDetails(
     crse_numb_in: number,
   };
 
-  // Perform the request in a retry loop
-  // (sometimes, we get rate limits/transport errors so this tries to mitigates them)
   const query = `?${concatParams(parameters)}`;
   const url = `https://oscar.gatech.edu/pls/bprod/bwckctlg.p_disp_course_detail${query}`;
-  const retries = 10;
-  let lastError: null | unknown = null;
-  for (let i = 0; i < retries; i++) {
-    // Use exponential backoff
-    // (each promise ends up getting staggered
-    //  so we shouldn't need any jitter to avoid a thundering herd)
-    const backoff = i ** 2 * 4000;
-    if (backoff > 0) await new Promise((r) => setTimeout(r, backoff));
 
-    try {
-      const requestResult = await axios.get<string>(url);
-      return [courseId, requestResult.data];
-    } catch (error) {
-      console.warn(
-        `An error occurred while fetching details for course ${courseId}`
-      );
-      if (i !== retries - 1) console.warn("Retrying after a backoff");
-      lastError = error;
-    }
+  // Perform the request in a retry loop
+  // (sometimes, we get rate limits/transport errors so this tries to mitigates them)
+  const maxAttemptCount = 10;
+  try {
+    const response = await backOff(() => axios.get<string>(url), {
+      // See https://github.com/coveooss/exponential-backoff for options API
+      jitter: "full",
+      numOfAttempts: maxAttemptCount,
+      retry: (err, attemptNumber) => {
+        error(`an error occurred while fetching details`, err, {
+          courseId,
+          url,
+          attemptNumber,
+          tryingAgain: attemptNumber < maxAttemptCount,
+        });
+        return true;
+      },
+    });
+    return response.data;
+  } catch (err) {
+    error(`exhausted retries for fetching details`, err, { courseId });
+    throw err;
   }
-
-  // If we exited the loop, then reject the promise by throwing an error
-  console.error(
-    `Exhausted retries for fetching details for course ${courseId}`
-  );
-  throw lastError;
 }
 
 /**

--- a/src/steps/prereqs/attach.ts
+++ b/src/steps/prereqs/attach.ts
@@ -1,3 +1,4 @@
+import { warn } from "../../log";
 import { TermData, Prerequisites } from "../../types";
 
 /**
@@ -18,9 +19,7 @@ export function attachPrereqs(
       // eslint-disable-next-line no-param-reassign
       termData.courses[courseId][2] = prerequisites[courseId];
     } else {
-      console.warn(
-        `Received prerequisite data for unknown course '${courseId}'`
-      );
+      warn(`received prerequisite data for unknown course`, { courseId });
     }
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/tiny-async-pool@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/tiny-async-pool/-/tiny-async-pool-1.0.0.tgz#9a88f701b736ab440c968b723456604cdcedbaed"
+  integrity sha512-d8RK1jg/piCgv5/jD8ta8uJOE10tU8MWExzL1Kf1kOjMaTuL5cW0eZ9ax001SSYa4Ecg6xzZBh/jM4GB7+5OAg==
+
 "@typescript-eslint/eslint-plugin@^4.23.0":
   version "4.23.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.23.0.tgz#29d3c9c81f6200b1fd6d8454cfb007ba176cde80"
@@ -741,6 +746,11 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+exponential-backoff@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.0.tgz#9409c7e579131f8bd4b32d7d8094a911040f2e68"
+  integrity sha512-oBuz5SYz5zzyuHINoe9ooePwSu0xApKWgeNzok4hZ5YKXFh9zrQBEM15CXqoZkJJPuI2ArvqjPQd8UKJA753XA==
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -767,6 +777,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-safe-stringify@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz#dc2af48c46cf712b683e849b2bbd446b32de936f"
+  integrity sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==
 
 fastq@^1.6.0:
   version "1.11.0"
@@ -1712,7 +1727,7 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.2.tgz#34b4c0d361eef262e07199dbef316d0f2ab11807"
   integrity sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
 
-"semver@2 || 3 || 4 || 5":
+"semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -1905,6 +1920,14 @@ through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+tiny-async-pool@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-async-pool/-/tiny-async-pool-1.2.0.tgz#22132957e18f8b6020a94b390d07718fd519cc71"
+  integrity sha512-PY/OiSenYGBU3c1nTuP1HLKRkhKFDXsAibYI5GeHbHw2WVpt6OFzAPIRP94dGnS66Jhrkheim2CHAXUNI4XwMg==
+  dependencies:
+    semver "^5.5.0"
+    yaassertion "^1.0.0"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -2052,6 +2075,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+yaassertion@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/yaassertion/-/yaassertion-1.0.2.tgz#f1a90166e1cc4ad44dbb71487009ebca017e9874"
+  integrity sha512-sBoJBg5vTr3lOpRX0yFD+tz7wv/l2UPMFthag4HGTMPrypBRKerjjS8jiEnNMjcAEtPXjbHiKE0UwRR1W1GXBg==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### Summary

Adds structured logging to the crawler (via the `src/log.ts` module), which includes both traditional log events and spans that automatically emit log events.

Additionally, this PR changes the orchestration of promises to all reside at the root level and perform term scraping and course scraping in parallel (with course scraping seeing a max concurrency limit, which is currently 256).

Finally, this removes the ad-hoc backoff code in favor of an actual backoff library with jitter (https://www.npmjs.com/package/exponential-backoff).

### Risks

I'm not sure how the concurrency is going to look in GitHub Actions, so I'm going to monitor this after merging it.
