### PR TITLE
Fix crawler not crawling current term

### DIFF
--- a/.github/workflows/crawling.yml
+++ b/.github/workflows/crawling.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           LOG_FORMAT: json
           NUM_TERMS: 2
+          ALWAYS_SCRAPE_CURRENT_TERM: 1
           DETAILS_CONCURRENCY: 256
           DATA_FOLDER: ./data
           


### PR DESCRIPTION
### Summary

Makes sure that, in addition to the most-recent terms, the 'current' term is also scraped. This is done by computing a rough estimate of the current term based on the current date.

### Motivation

At the beginning of 2023, Oscar had all 3 terms for the year (Spring, Summer, Fall) listed (but no courses were in Summer/Fall). In the past (to my knowledge), this wasn't the case; terms would only appear once the course schedule was released (in the middle of the prior semester). The crawler is configured to scrape the most recent 2 terms, so to make sure it continues to scrape the Spring schedule during the Spring semester, this was added as a workaround.
